### PR TITLE
fix: Clear CodeTeams::Plugin registries when busting caches

### DIFF
--- a/code_teams.gemspec
+++ b/code_teams.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'code_teams'
-  spec.version       = '1.0.1'
+  spec.version       = '1.0.2'
   spec.authors       = ['Gusto Engineers']
   spec.email         = ['dev@gusto.com']
   spec.summary       = 'A low-dependency gem for declaring and querying engineering teams'

--- a/lib/code_teams.rb
+++ b/lib/code_teams.rb
@@ -60,6 +60,7 @@ module CodeTeams
   # The primary reason this is helpful is for clients of CodeTeams who want to test their code, and each test context has different set of teams
   sig { void }
   def self.bust_caches!
+    Plugin.bust_caches!
     @all = nil
     @index_by_name = nil
   end

--- a/lib/code_teams/plugin.rb
+++ b/lib/code_teams/plugin.rb
@@ -61,6 +61,16 @@ module CodeTeams
       T.unsafe(registry_for_team[self])
     end
 
+    sig { void }
+    def self.bust_caches!
+      all_plugins.each(&:clear_team_registry!)
+    end
+
+    sig { void }
+    def self.clear_team_registry!
+      @registry = nil
+    end
+
     private_class_method :registry
     private_class_method :register_team
   end

--- a/spec/lib/plugin_spec.rb
+++ b/spec/lib/plugin_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe CodeTeams::Plugin do
+  def write_team_yml(extra_data: false)
+    write_file('config/teams/my_team.yml', <<~YML.strip)
+      name: My Team
+      extra_data: #{extra_data}
+    YML
+  end
+
+  before do
+    CodeTeams.bust_caches!
+
+    test_plugin_class = Class.new(described_class) do
+      def extra_data
+        @team.raw_hash['extra_data']
+      end
+    end
+    stub_const('TestPlugin', test_plugin_class)
+  end
+
+  describe '.bust_caches!' do
+    it 'clears all plugins team registries ensuring cached configs are purged' do
+      write_team_yml(extra_data: true)
+      team = CodeTeams.find('My Team')
+      expect(TestPlugin.for(team).extra_data).to be(true)
+      write_team_yml(extra_data: false)
+      CodeTeams.bust_caches!
+      team = CodeTeams.find('My Team')
+      expect(TestPlugin.for(team).extra_data).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
Hey all! I stubbed my toe on this while writing tests that manipulated team configs. This ensures stale team configs are purged when calling `CodeTeams.bust_caches!`

Let me know if you have any concerns with this approach or would like different / additional testing.