### PR TITLE
chore: Bump code_teams version and sorbet in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    code_teams (1.0.1)
+    code_teams (1.0.2)
       sorbet-runtime
 
 GEM

--- a/sorbet/rbi/todo.rbi
+++ b/sorbet/rbi/todo.rbi
@@ -3,3 +3,4 @@
 
 # typed: strong
 module ::RSpec; end
+module ::TestPlugin; end


### PR DESCRIPTION
Looks like I missed a step when doing the version bump in #12, which [broke CI + CD](https://github.com/rubyatscale/code_teams/actions/runs/5535407769/jobs/10101662372).

This patch updates `Gemfile.lock` and adds the new test constant to the `todo.rbi` file.
