### PR TITLE
Simplify example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,7 @@ class MyGithubPlugin < CodeTeams::Plugin
   end
 
   def member?(user)
-    members = github.members
-    return false unless members
-
-    members.include?(user)
+    github.members.include?(user)
   end
 
   sig { override.params(teams: T::Array[CodeTeams::Team]).returns(T::Array[String]) }


### PR DESCRIPTION
Just something I spotted reading the README.

Since `member?` accesses `github.members`:

```ruby
def github
  raw_github = @team.raw_hash['github'] || {}

  GithubStruct.new(
    raw_github['team'],
    raw_github['members'] || []
  )
end
```

we can simplify the predicate.