### PR TITLE
Eliminate unnecessary leading ::

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Your plugins can be as simple or as complex as you want. Here are some other thi
 You'll want to ensure that all teams are valid in your CI environment. We recommend running code like this in CI:
 ```ruby
 require 'code_teams'
-errors = ::CodeTeams.validation_errors(::CodeTeams.all)
+
+errors = CodeTeams.validation_errors(CodeTeams.all)
 if errors.any?
   abort <<~ERROR
     Team validation failed with the following errors:


### PR DESCRIPTION
Another simplification.

The suggested script for CI is a simple one. A relative constant at the top level is resolved against `Object`, there is no need for `::` here, and it is not really idiomatic.

You use `::` when you are within some namespace and want to reach a top-level constant avoiding the risk of some other one being found during lookup.

But here, this is simple, you are not in a namespace.