### PR TITLE
Add AGENTS.md and CLAUDE.md for AI coding agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents when working with code in this repository.
+
+## What this project is
+
+`code_teams` is a low-dependency, plugin-based Ruby gem for declaring and querying engineering teams within a codebase. Teams are defined in `config/teams/*.yml` files, and plugins extend validation and querying behavior per organization.
+
+## Commands
+
+```bash
+bundle install
+
+# Run all tests (RSpec)
+bundle exec rspec
+
+# Run a single spec file
+bundle exec rspec spec/path/to/spec.rb
+
+# Lint
+bundle exec rubocop
+bundle exec rubocop -a  # auto-correct
+
+# Type checking (Sorbet)
+bundle exec srb tc
+```
+
+## Architecture
+
+- `lib/code_teams.rb` — public API: `CodeTeams.all`, `CodeTeams.find`, team plugin registration
+- `lib/code_teams/` — `Team` struct, YAML parsing, plugin interface, and built-in plugins
+- `spec/` — RSpec tests; `spec/fixtures/` holds sample `config/teams/` directories

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
-# AGENTS.md
-
 This file provides guidance to AI coding agents when working with code in this repository.
 
 ## What this project is
@@ -29,4 +27,4 @@ bundle exec srb tc
 
 - `lib/code_teams.rb` — public API: `CodeTeams.all`, `CodeTeams.find`, team plugin registration
 - `lib/code_teams/` — `Team` struct, YAML parsing, plugin interface, and built-in plugins
-- `spec/` — RSpec tests; `spec/fixtures/` holds sample `config/teams/` directories
+- `spec/` — RSpec tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` with codebase guidance for AI coding agents (commands, architecture)
- Adds `CLAUDE.md` containing just `@AGENTS.md`, following the [Claude Code best practice](https://code.claude.com/docs/en/claude-code-on-the-web#best-practices) of sharing a single instruction file across agents

This makes the same guidance available to Claude Code (via `CLAUDE.md` import) and other agents like Codex that look for `AGENTS.md`.